### PR TITLE
Fix for Boost 1.59.0 compatibility.

### DIFF
--- a/test/sequential_generation/RandomDistributionTestSuite.cpp
+++ b/test/sequential_generation/RandomDistributionTestSuite.cpp
@@ -23,6 +23,7 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_MODULE RandomDistributionTest
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
 
 // using namespace boost;
 namespace ba = boost::accumulators;
@@ -38,7 +39,11 @@ struct UnitTestConfig {
   /** Constructor. */
   UnitTestConfig() {
     boost_utf::unit_test_log.set_stream (utfReportStream);
+#if BOOST_VERSION >= 105900
+    boost_utf::unit_test_log.set_format (boost_utf::OF_XML);
+#else
     boost_utf::unit_test_log.set_format (boost_utf::XML);
+#endif
     boost_utf::unit_test_log.set_threshold_level (boost_utf::log_test_units);
     //boost_utf::unit_test_log.set_threshold_level (boost_utf::log_successful_tests);
   }

--- a/test/sequential_generation/SimulateTestSuite.cpp
+++ b/test/sequential_generation/SimulateTestSuite.cpp
@@ -19,6 +19,7 @@
 // Boost Unit Test Framework (UTF)
 #define BOOST_TEST_MODULE TraDemGenTest
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
 
 // using namespace boost;
 namespace ba = boost::accumulators;
@@ -34,7 +35,11 @@ struct UnitTestConfig {
   /** Constructor. */
   UnitTestConfig() {
     boost_utf::unit_test_log.set_stream (utfReportStream);
+#if BOOST_VERSION >= 105900
+    boost_utf::unit_test_log.set_format (boost_utf::OF_XML);
+#else
     boost_utf::unit_test_log.set_format (boost_utf::XML);
+#endif
     boost_utf::unit_test_log.set_threshold_level (boost_utf::log_test_units);
     //boost_utf::unit_test_log.set_threshold_level (boost_utf::log_successful_tests);
   }

--- a/test/trademgen/DemandGenerationTestSuite.cpp
+++ b/test/trademgen/DemandGenerationTestSuite.cpp
@@ -15,6 +15,7 @@
 #define BOOST_TEST_MAIN
 #define BOOST_TEST_MODULE DemandGenerationTest
 #include <boost/test/unit_test.hpp>
+#include <boost/version.hpp>
 // StdAir
 #include <stdair/stdair_basic_types.hpp>
 #include <stdair/basic/BasConst_General.hpp>
@@ -43,7 +44,11 @@ struct UnitTestConfig {
   /** Constructor. */
   UnitTestConfig() {
     boost_utf::unit_test_log.set_stream (utfReportStream);
+#if BOOST_VERSION >= 105900
+    boost_utf::unit_test_log.set_format (boost_utf::OF_XML);
+#else
     boost_utf::unit_test_log.set_format (boost_utf::XML);
+#endif
     boost_utf::unit_test_log.set_threshold_level (boost_utf::log_test_units);
     //boost_utf::unit_test_log.set_threshold_level (boost_utf::log_successful_tests);
   }


### PR DESCRIPTION
Boost.Test has major changes in 1.59.0 including renaming the
XML enumerator to OF_XML.
